### PR TITLE
Fixed Missing Lines

### DIFF
--- a/dst_scoring_model/get_pinnacle_data.py
+++ b/dst_scoring_model/get_pinnacle_data.py
@@ -27,4 +27,5 @@ def get_lines() -> pd.DataFrame:
                              event['lines']['3']['spread']['point_spread_home'],
                              'opponent': event['teams'][0]['name']}])
     spread_df = pd.DataFrame(data=spread_list)
+    spread_df['points_allowed'].fillna(27, inplace=True)
     return spread_df


### PR DESCRIPTION
Addressing #6. This PR merely fills nas when there is not data from the Pinnacle lines for games with 27 points against. This will mean that the team will get 0 points from the` points_allowed_score()` function, thereby not impacting the prediction. 